### PR TITLE
Feat: Add rate limiting to api routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@upstash/redis": "^1.16.0",
         "@vercel/analytics": "^0.1.7-beta.1",
         "classnames": "^2.3.2",
+        "lru-cache": "^7.14.1",
         "next": "13.0.0",
         "openai": "^3.1.0",
         "react": "18.2.0",
@@ -2803,14 +2804,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/merge2": {
@@ -3771,6 +3769,17 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -6440,12 +6449,9 @@
       }
     },
     "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
     },
     "merge2": {
       "version": "1.4.1",
@@ -7071,6 +7077,16 @@
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "sharp": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@upstash/redis": "^1.16.0",
     "@vercel/analytics": "^0.1.7-beta.1",
     "classnames": "^2.3.2",
+    "lru-cache": "^7.14.1",
     "next": "13.0.0",
     "openai": "^3.1.0",
     "react": "18.2.0",

--- a/pages/api/image.ts
+++ b/pages/api/image.ts
@@ -2,6 +2,12 @@ import { NextApiRequest, NextApiResponse } from "next";
 const QSTASH = `https://qstash.upstash.io/v1/publish/`;
 const DALL_E = "https://api.openai.com/v1/images/generations";
 const VERCEL_URL = "https://dalle-2.vercel.app";
+import rateLimit from "../../utils/rate-limit";
+
+const limiter = rateLimit({
+  uniqueTokenPerInterval: 500, // 500 unique tokens per interval
+  interval: 60000, // 1 minute
+});
 
 export default async function handler(
   req: NextApiRequest,
@@ -9,6 +15,15 @@ export default async function handler(
 ) {
   const { prompt } = req.query;
   try {
+    // Check if the user has exceeded maximum number of requests per minute
+    await limiter.check(res, 5, "CACHE_TOKEN").catch((e) => {
+      // 5 requests per minute
+      return res.status(429).json({
+        message:
+          "You have exceeded the maximum number of requests. Please try again in a minute.",
+        description: "The user has exceeded the maximum number of requests",
+      });
+    });
     const response = await fetch(`${QSTASH + DALL_E}`, {
       method: "POST",
       headers: {

--- a/pages/api/poll.ts
+++ b/pages/api/poll.ts
@@ -1,12 +1,28 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import redis from "../../utils/redis";
+import rateLimit from "../../utils/rate-limit";
+
+const limiter = rateLimit({
+  uniqueTokenPerInterval: 500, // 500 unique tokens per interval
+  interval: 60000, // 1 minute
+});
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
   const { id }: any = req.query;
+
   try {
+    // Check if the user has exceeded maximum number of requests per minute
+    await limiter.check(res, 60, "CACHE_TOKEN").catch((e) => {
+      // 60 requests per minute (polling every second)
+      return res.status(429).json({
+        message:
+          "You have exceeded the maximum number of requests. Please try again in a minute.",
+        description: "The user has exceeded the maximum number of requests",
+      });
+    });
     const data = await redis.get(id);
     if (!data) return res.status(404).json({ message: "No data found" });
     else return res.status(200).json(data);

--- a/utils/rate-limit.ts
+++ b/utils/rate-limit.ts
@@ -1,0 +1,35 @@
+import type { NextApiResponse } from "next";
+import LRU from "lru-cache";
+
+type Options = {
+  uniqueTokenPerInterval?: number;
+  interval?: number;
+};
+
+export default function rateLimit(options?: Options) {
+  const tokenCache = new LRU({
+    max: options?.uniqueTokenPerInterval || 500,
+    ttl: options?.interval || 60000,
+  });
+
+  return {
+    check: (res: NextApiResponse, limit: number, token: string) =>
+      new Promise<void>((resolve, reject) => {
+        const tokenCount = (tokenCache.get(token) as number[]) || [0];
+        if (tokenCount[0] === 0) {
+          tokenCache.set(token, tokenCount);
+        }
+        tokenCount[0] += 1;
+
+        const currentUsage = tokenCount[0];
+        const isRateLimited = currentUsage >= limit;
+        res.setHeader("X-RateLimit-Limit", limit);
+        res.setHeader(
+          "X-RateLimit-Remaining",
+          isRateLimited ? 0 : limit - currentUsage
+        );
+
+        return isRateLimited ? reject() : resolve();
+      }),
+  };
+}


### PR DESCRIPTION
As per Next.js rate limiting guides, lru-cache was used to api rate limit api/poll and api/image. Since the client is polling once per second, the rate limit on api/poll was set to 60 requests per minute.